### PR TITLE
add OpenAI Instruct model controller

### DIFF
--- a/Assets/Scenes/Main scene.unity
+++ b/Assets/Scenes/Main scene.unity
@@ -3040,6 +3040,7 @@ Transform:
   - {fileID: 456539814}
   - {fileID: 837487285}
   - {fileID: 247817182}
+  - {fileID: 1359570594}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -19545,6 +19546,60 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1347582746}
   m_Mesh: {fileID: 8004767503077035365, guid: 808fd82513e22fd428f34b5d9feaf406, type: 3}
+--- !u!1 &1359570593
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1359570594}
+  - component: {fileID: 1359570595}
+  m_Layer: 0
+  m_Name: GPTInstructManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1359570594
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359570593}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 240433591}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1359570595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359570593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07078df585ee5744e8806dc6f42ba61e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outputString: 
+  outputLines: []
+  director: {fileID: 456539815}
+  examples:
+  - {fileID: 4900000, guid: 0ddd670a48222b942b430793aac07fc2, type: 3}
+  - {fileID: 4900000, guid: 16bbee1c7ac17ed4889bae9be985f75f, type: 3}
+  systemMessage: {fileID: 4900000, guid: 1679b83724c4cdd468864a6ac26d2a37, type: 3}
+  useDavinci: 0
+  maxTokens: 2000
+  temperature: 0.6
 --- !u!1 &1371130782
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AIControllers/OpenAIInstructController.cs
+++ b/Assets/Scripts/AIControllers/OpenAIInstructController.cs
@@ -1,0 +1,203 @@
+﻿using OpenAI_API;
+using OpenAI_API.Chat;
+using OpenAI_API.Models;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+using System.Threading.Tasks;
+using System.Net.Http;
+using Assets.Scripts.AIControllers;
+using OpenAI_API.Completions;
+
+
+// this script is used to get responses from chatgpt, but using the text competion gpt-3.5-turbo-instruct model instead of chat one
+public class OpenAIInstructController : AIController 
+{
+    private OpenAIAPI api;
+
+    [SerializeField]
+    private string outputString;
+    public override string OutputString
+    {
+        get
+        {
+            return outputString;
+        }
+        set
+        {
+            outputString = value;
+        }
+    }
+
+    [SerializeField]
+    private string[] outputLines;
+    public override string[] OutputLines
+    {
+        get
+        {
+            return outputLines;
+        }
+        set
+        {
+            outputLines = value;
+        }
+    }
+
+    [SerializeField]
+    private SceneDirector director;
+    public override SceneDirector Director
+    {
+        get
+        {
+            return director;
+        }
+        set
+        {
+            director = value;
+        }
+    }
+
+    [SerializeField]
+    private List<TextAsset> examples;
+    public List<TextAsset> Examples
+    {
+        get
+        {
+            return examples;
+        }
+        set
+        {
+            examples = value;
+        }
+    }
+
+    [SerializeField]
+    private TextAsset systemMessage;
+    public override TextAsset SystemMessage
+    {
+        get
+        {
+            return systemMessage;
+        }
+        set
+        {
+            systemMessage = value;
+        }
+    }
+
+    public bool useDavinci = false;
+    public int maxTokens = 2000;
+    public double temperature = 0.6;
+
+    private string loadedSystemMessageWithExamples;
+
+    public override void Init()
+    {
+        // This line gets your API key (and could be slightly different on Mac/Linux)
+        string key = Environment.GetEnvironmentVariable("OPENAI_API_KEY", EnvironmentVariableTarget.User);
+        if (string.IsNullOrEmpty(key))
+        {
+            Debug.LogError("OPEN AI KEY NOT FOUND");
+            return;
+        }
+        api = new OpenAIAPI(key);
+
+        string text = systemMessage.text;
+
+        string nextLine = " Here are some example scripts:\n";
+
+        foreach (TextAsset example in examples)
+        {
+            text += nextLine;
+            text += example.text;
+            nextLine = "\nHere is another example: \n";
+        }
+
+        // im putting this one for async function to get this text instead of recreating it every fucking time
+        loadedSystemMessageWithExamples = text;
+    }
+
+
+    public override void Clear()
+    {
+        // this should not be required as you don't necessarily need to clear completion model
+    }
+
+    // ok this is the actual interaction with chatgpt.
+    public override async Task<string> EnterPromptAndGetResponse(string inputPrompt)
+    {
+        // Don't submit empty messages
+        if (inputPrompt.Length < 1)
+        {
+            Debug.Log("message is empty");
+            return null;
+        }
+
+        inputPrompt += ". Make sure to use light profanity like frick, shoot and crap. Scripts should have at least 30 lines of dialog.";
+
+        string fullPrompt = loadedSystemMessageWithExamples + "\nScript topic: " + inputPrompt + "\n\n[Start of script]\n";
+
+        CompletionRequest completionRequest = new CompletionRequest(
+            prompt: fullPrompt,
+            model: useDavinci ? Model.DavinciText002 : Model.GPTTurboInstruct,
+            max_tokens: maxTokens,
+            temperature: temperature
+            ) ;
+
+        Debug.Log($"GPT Instruct model used: {completionRequest.Model}, temp: {temperature}");
+
+        // Retry logic
+        int retryCount = 0;
+        const int maxRetryCount = 3;
+
+        string response = "";
+
+        while (retryCount < maxRetryCount)
+        {
+            try
+            {
+                // Send the request to OpenAI
+                var chatResult = await api.Completions.CreateCompletionAsync(completionRequest);
+
+
+                // store response in a variable to return
+                response = chatResult.ToString();
+
+                // Exit the retry loop if the request is successful
+                break;
+            }
+            catch (HttpRequestException ex)
+            {
+                if (ex.Message.Contains("429"))
+                {
+                    // Model overloaded, retry after a delay
+                    retryCount++;
+                    Debug.LogWarning("TooManyRequests error. Retrying in 1 second...");
+                    await Task.Delay(1000); // Wait for 1 second before retrying
+                }
+                else
+                {
+                    // Other HTTP request error occurred, log the exception
+                    Debug.LogError($"HTTP request error: {ex}");
+                    Debug.Log("Retrying in 1 second...");
+                    retryCount++;
+                    await Task.Delay(1000);
+                    // break;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Other exceptions occurred, log the exception
+                Debug.LogError($"Error: {ex}");
+                break;
+            }
+        }
+
+        //return the message
+        return response;
+    }
+}

--- a/Assets/Scripts/AIControllers/OpenAIInstructController.cs.meta
+++ b/Assets/Scripts/AIControllers/OpenAIInstructController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07078df585ee5744e8806dc6f42ba61e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenAISlurDetector.cs
+++ b/Assets/Scripts/OpenAISlurDetector.cs
@@ -23,6 +23,8 @@ public class OpenAISlurDetector : MonoBehaviour
 
     private bool isEnabled = true;
 
+    public bool useChatGPT4 = true;
+
     void Start()
     {
         // this is the system message. its probably shit but it kinda works
@@ -169,9 +171,9 @@ public class OpenAISlurDetector : MonoBehaviour
                 var chatResult = await api.Chat.CreateChatCompletionAsync(new ChatRequest()
                 {
 
-                    // Model = useChatGPT4 ? Model.ChatGPT4_8k : Model.ChatGPTTurbo16k,
+                    Model = useChatGPT4 ? Model.ChatGPT4_8k : Model.ChatGPTTurbo16k,
                     // Model = Model.ChatGPTTurbo16k,
-                    Model = Model.ChatGPT4_8k,
+                    //Model = Model.ChatGPT4_8k,
                     // Model = Model.ChatGPT4_8k_functions,
                     // Functions = GetFunctionList(),
                     // Function_Call = "auto",

--- a/Assets/ThirdPartyCode/OkGoDoIt/OpenAI_API/Model/Model.cs
+++ b/Assets/ThirdPartyCode/OkGoDoIt/OpenAI_API/Model/Model.cs
@@ -123,6 +123,11 @@ namespace OpenAI_API.Models
 		/// </summary>
 		public static Model CushmanCode => new Model("code-cushman-001") { OwnedBy = "openai" };
 
+        /// <summary>
+        /// Similar capabilities to text-davinci-003 but trained with supervised fine-tuning instead of reinforcement learning
+        /// </summary>
+        public static Model DavinciText002 => new Model("text-davinci-002") { OwnedBy = "openai" };
+
 		/// <summary>
 		/// Most capable Codex model. Particularly good at translating natural language to code. In addition to completing code, also supports inserting completions within code.
 		/// </summary>
@@ -132,6 +137,17 @@ namespace OpenAI_API.Models
 		/// OpenAI offers one second-generation embedding model for use with the embeddings API endpoint.
 		/// </summary>
 		public static Model AdaTextEmbedding => new Model("text-embedding-ada-002") { OwnedBy = "openai" };
+
+        /// <summary>
+        /// Similar capabilities as text-davinci-003 but compatible with legacy Completions endpoint and not Chat Completions.
+        /// </summary>
+        public static Model GPTTurboInstruct => new Model("gpt-3.5-turbo-instruct") { OwnedBy = "openai" };
+
+        /// <summary>
+		/// Snapshot of gpt-3.5-turbo-instruct from September 14th 2023. Unlike gpt-3.5-turbo-instruct, this model will not receive updates, and will be deprecated 3 months after a new version is released.
+        /// Similar capabilities as text-davinci-003 but compatible with legacy Completions endpoint and not Chat Completions.
+        /// </summary>
+        public static Model GPTTurboInstruct0914 => new Model("gpt-3.5-turbo-instruct-0914") { OwnedBy = "openai" };
 
 		/// <summary>
 		/// Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with the latest model iteration.


### PR DESCRIPTION
OpenAI has recently released a new model called 'gpt-3.5-turbo-instruct' which is pretty much unfiltered completion model of gpt3.5 so slightly less capable but certainly more unhinged than chatgpt4 model.

i updated the external openai_api module to allow selecting of the new models, and created a new AI controller (based on @steven4547466 refactor). 
the instruct controller is mostly a copy of OpenAIController, lets be honest here, if it works then i copy. simple rule.
but instead of using the Chat completions api, i used the text completions api to make use of instruct model.
the instruct model is more focused on following instructions rather than chat abilities, at least that's how i understand it. 

to use this controller, i created an empty game object called 'GPTInstructController' where this script is attached. it's preconfigured to have similar variables as standard gpt controller. thanks to steven's pr it is an easy drop-in replacement of current controller in 'Whole thing manager' - just change 'AI Controller' to gpt instruct.

tldr: for more unhinged ai responses switch AI Controller in whole thing manager to gpt instruct.